### PR TITLE
Move vsphere specific methods out of vmpooler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       rubocop-ast (>= 1.0.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.14.0)
+    rubocop-ast (1.15.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -160,7 +160,7 @@ GEM
     thrift (0.15.0)
     tilt (2.0.10)
     unicode-display_width (1.8.0)
-    vmpooler (2.0.0)
+    vmpooler (2.1.0)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.2)
       net-ldap (~> 0.16)
@@ -197,7 +197,7 @@ DEPENDENCIES
   rubocop (~> 1.1.0)
   simplecov (>= 0.11.2)
   thor (~> 1.0, >= 1.0.1)
-  vmpooler (~> 2.0)
+  vmpooler (~> 2.1)
   vmpooler-provider-vsphere!
   yarjuf (>= 2.0)
 

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -61,7 +61,7 @@ EOT
 ---
 :config:
 :providers:
-  :mock:
+  :vsphere:
 :pools:
   - name: '#{pool}'
     size: 1
@@ -1060,7 +1060,7 @@ EOT
     end
   end
 
-  describe '#purge_unused_vms_and_folders' do
+  describe '#purge_unused_vms_and_resources' do
     let(:config) { YAML.load(<<-EOT
 ---
 :config: {}
@@ -1074,104 +1074,46 @@ EOT
     }
 
     it 'should return when purging is not enabled' do
-      expect(subject.purge_unused_vms_and_folders).to be_nil
+      expect(subject.purge_unused_vms_and_resources).to be_nil
     end
 
     context 'with purging enabled globally' do
       before(:each) do
-        config[:config]['purge_unconfigured_folders'] = true
+        config[:config]['purge_unconfigured_resources'] = true
         expect(Thread).to receive(:new).and_yield
       end
 
       it 'should run a purge for each provider' do
-        expect(subject).to receive(:purge_vms_and_folders)
+        expect(subject).to receive(:purge_vms_and_resources)
 
-        subject.purge_unused_vms_and_folders
+        subject.purge_unused_vms_and_resources
       end
 
       it 'should log when purging fails' do
-        expect(subject).to receive(:purge_vms_and_folders).and_raise(RuntimeError,'MockError')
+        expect(subject).to receive(:purge_vms_and_resources).and_raise(RuntimeError,'MockError')
         expect(logger).to receive(:log).with('s', '[!] failed while purging provider mock VMs and folders with an error: MockError')
 
-        subject.purge_unused_vms_and_folders
+        subject.purge_unused_vms_and_resources
       end
     end
 
     context 'with purging enabled on the provider' do
       before(:each) do
-        config[:providers][:mock]['purge_unconfigured_folders'] = true
+        config[:providers][:mock]['purge_unconfigured_resources'] = true
         expect(Thread).to receive(:new).and_yield
       end
 
       it 'should run a purge for the provider' do
-        expect(subject).to receive(:purge_vms_and_folders)
+        expect(subject).to receive(:purge_vms_and_resources)
 
-        subject.purge_unused_vms_and_folders
+        subject.purge_unused_vms_and_resources
       end
     end
   end
 
-  describe '#pool_folders' do
-    let(:folder_name) { 'myinstance' }
-    let(:folder_base) { 'vmpooler' }
-    let(:folder) { [folder_base,folder_name].join('/') }
-    let(:datacenter) { 'dc1' }
+  describe '#purge_vms_and_resources' do
     let(:provider_name) { 'mock_provider' }
-    let(:expected_response) {
-      {
-        folder_name => "#{datacenter}/vm/#{folder_base}"
-      }
-    }
-    let(:config) { YAML.load(<<-EOT
----
-:providers:
-  :mock:
-:pools:
-  - name: '#{pool}'
-    folder: '#{folder}'
-    size: 1
-    datacenter: '#{datacenter}'
-    provider: '#{provider_name}'
-  - name: '#{pool}2'
-    folder: '#{folder}'
-    size: 1
-    datacenter: '#{datacenter}'
-    provider: '#{provider_name}2'
-EOT
-      )
-    }
-
-    context 'when evaluating pool folders' do
-      before do
-        expect(subject).not_to be_nil
-        # Inject mock provider into global variable - Note this is a code smell
-        $providers = { provider_name => provider }
-      end
-
-      it 'should return a list of pool folders' do
-        expect(provider).to receive(:get_target_datacenter_from_config).with(pool).and_return(datacenter)
-
-        expect(subject.pool_folders(provider_name)).to eq(expected_response)
-      end
-
-      it 'should raise an error when the provider fails to get the datacenter' do
-        expect(provider).to receive(:get_target_datacenter_from_config).with(pool).and_raise('mockerror')
-
-        expect{ subject.pool_folders(provider_name) }.to raise_error(RuntimeError, 'mockerror')
-      end
-    end
-  end
-
-  describe '#purge_vms_and_folders' do
-    let(:folder_name) { 'myinstance' }
-    let(:folder_base) { 'vmpooler' }
-    let(:datacenter) { 'dc1' }
-    let(:full_folder_path) { "#{datacenter}/vm/folder_base" }
-    let(:configured_folders) { { folder_name => full_folder_path } }
-    let(:base_folders) { [ full_folder_path ] }
-    let(:folder) { [folder_base,folder_name].join('/') }
-    let(:provider_name) { 'mock_provider' }
-    let(:whitelist) { nil }
+    let(:allowlist) { nil }
     let(:config) { YAML.load(<<-EOT
 ---
 :config: {}
@@ -1179,9 +1121,7 @@ EOT
   :mock_provider: {}
 :pools:
   - name: '#{pool}'
-    folder: '#{folder}'
     size: 1
-    datacenter: '#{datacenter}'
     provider: '#{provider_name}'
 EOT
       )
@@ -1194,20 +1134,18 @@ EOT
         $providers = { provider_name => provider }
       end
 
-      it 'should run purge_unconfigured_folders' do
-        expect(subject).to receive(:pool_folders).and_return(configured_folders)
-        expect(provider).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist)
-        expect(provider).to receive(:provider_config).and_return({})
+      it 'should run purge_unconfigured_resources' do
+        expect(provider).to receive(:purge_unconfigured_resources).with(allowlist)
+        allow(provider).to receive(:provider_config).and_return({})
 
-        subject.purge_vms_and_folders(provider_name)
+        subject.purge_vms_and_resources(provider_name)
       end
 
       it 'should raise any errors' do
-        expect(subject).to receive(:pool_folders).and_return(configured_folders)
-        expect(provider).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist).and_raise('mockerror')
-        expect(provider).to receive(:provider_config).and_return({})
+        expect(provider).to receive(:purge_unconfigured_resources).with(allowlist).and_raise('mockerror')
+        allow(provider).to receive(:provider_config).and_return({})
 
-        expect{ subject.purge_vms_and_folders(provider_name) }.to raise_error(RuntimeError, 'mockerror')
+        expect{ subject.purge_vms_and_resources(provider_name) }.to raise_error(RuntimeError, 'mockerror')
       end
     end
   end

--- a/vmpooler-provider-vsphere.gemspec
+++ b/vmpooler-provider-vsphere.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency 'rbvmomi', '>= 2.1', '< 4.0'
   
-  s.add_development_dependency 'vmpooler', '~> 2.0'
+  s.add_development_dependency 'vmpooler', '~> 2.1' # renaming done in version 2.1
 
   # Testing dependencies
   s.add_development_dependency 'climate_control', '>= 0.2.0'


### PR DESCRIPTION
VMPooler has the vSphere provider taken out, moving some vSphere related
methods to the provider:

1) pool_folders
2) get_base_folders

And the related spec tests. At the same time renaming some configuration and code items to remove harmful terminology. Note this version of the vSphere provider needs to run on VMPooler that also contain the renaming changes (version >2.1)

depends on https://github.com/puppetlabs/vmpooler/pull/467 and a release of vmpooler >2.1