### PR TITLE
(RE-15710) Fix IP address that is returned and increase timeout

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -603,9 +603,11 @@ module Vmpooler
           ip_loop_delay = 1
           ip_loop_count = 1
           ip = nil
+          invalid_addresses = /(0|169)\.(0|254)\.\d+\.\d+/
           while ip.nil?
             sleep(ip_loop_delay)
             ip = vm_object.guest_ip
+            ip = nil if !ip.nil? && ip.match?(invalid_addresses)
             unless ip_maxloop == 0
               break if ip_loop_count >= ip_maxloop
 

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -599,7 +599,7 @@ module Vmpooler
           boottime = vm_object.runtime.bootTime if vm_object.runtime&.bootTime
           powerstate = vm_object.runtime.powerState if vm_object.runtime&.powerState
 
-          ip_maxloop = 60
+          ip_maxloop = 120
           ip_loop_delay = 1
           ip_loop_count = 1
           ip = nil

--- a/spec/rbvmomi_helper.rb
+++ b/spec/rbvmomi_helper.rb
@@ -818,7 +818,7 @@ end
 def mock_RbVmomi_VIM_VirtualMachine(options = {})
   options[:snapshot_tree] = nil if options[:snapshot_tree].nil?
   options[:name] = 'VM' + rand(65536).to_s if options[:name].nil?
-  options[:ip] = '169.254.255.255' if options[:ip].nil?
+  options[:ip] = '192.168.0.2' if options[:ip].nil?
   options[:path] = [] if options[:path].nil?
 
   mock = MockVirtualMachine.new()

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -580,11 +580,41 @@ EOT
       end
     end
 
+    context 'when VM exists but contains a self assigned ip' do
+      let(:vm_object) { mock_RbVmomi_VIM_VirtualMachine({
+          :name => vmname,
+          :ip => '169.254.255.255',
+        })
+      }
+
+      it 'should return nil ip' do
+        allow(subject).to receive(:sleep)
+        result = subject.get_vm(poolname,vmname)
+
+        expect(result['ip']).to eq(nil)
+      end
+    end
+
+    context 'when VM exists but contains an invalid ip' do
+      let(:vm_object) { mock_RbVmomi_VIM_VirtualMachine({
+          :name => vmname,
+          :ip => '0.0.0.0',
+        })
+      }
+
+      it 'should return nil for ip' do
+        allow(subject).to receive(:sleep)
+        result = subject.get_vm(poolname,vmname)
+
+        expect(result['ip']).to eq(nil)
+      end
+    end
+
     context 'when VM exists and contains all information' do
       let(:vm_hostname) { "#{vmname}.demo.local" }
       let(:boot_time) { Time.now }
       let(:power_state) { 'MockPowerState' }
-      let(:ip) { '169.254.255.255' }
+      let(:ip) { '192.168.0.2' }
 
       let(:vm_object) { mock_RbVmomi_VIM_VirtualMachine({
           :name => vmname,


### PR DESCRIPTION
Addresses `0.0.0.0` and `169.254.x.x` should not be returned since connectivity to the VM would not be working. With this change `nil` is returned at the end of the timeout instead of an empty string, since VMPooler should not be using an empty string to pass to a DNS provider. Also, increase the timeout to obtain an IP for very slow or problematic VMs.