### PR TITLE
Add provider method get_provisioning_trace

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -1240,6 +1240,8 @@ module Vmpooler
             # find events for vm
             events = event_manager.QueryEvents(filter: event_filter_spec)
           end
+          return nil if !events || events.empty?
+
           # convert events to json, include only the fullFormattedMessage
           messages = events.map(&:fullFormattedMessage)
           JSON.generate(messages)


### PR DESCRIPTION
Adds a method to generate a JSON description of the vsphere events. This is now only added to this provider, so it's not a required provider method at this time.

Fixes https://github.com/puppetlabs/vmpooler-provider-vsphere/issues/55

Depends on https://github.com/puppetlabs/vmpooler/pull/629