### PR TITLE
(maint) Release prep 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.4.0](https://github.com/puppetlabs/vmpooler-provider-vsphere/tree/3.4.0) (2026-03-17)
+
+[Full Changelog](https://github.com/puppetlabs/vmpooler-provider-vsphere/compare/3.3.4...3.4.0)
+
+**New features:**
+
+- \(P4DEVOPS-9438\) Wire circuit breaker into vSphere provider with connection timeouts [\#62](https://github.com/puppetlabs/vmpooler-provider-vsphere/pull/62) ([smahima27](https://github.com/smahima27))
+
 ## [3.3.4](https://github.com/puppetlabs/vmpooler-provider-vsphere/tree/3.3.4) (2023-08-30)
 
 [Full Changelog](https://github.com/puppetlabs/vmpooler-provider-vsphere/compare/3.3.3...3.3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vmpooler-provider-vsphere (3.3.4)
+    vmpooler-provider-vsphere (3.4.0)
       rbvmomi2 (>= 3.1, < 4.0)
       vmpooler (~> 3.0)
 

--- a/lib/vmpooler-provider-vsphere/version.rb
+++ b/lib/vmpooler-provider-vsphere/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VmpoolerProviderVsphere
-  VERSION = '3.3.4'
+  VERSION = '3.4.0'
 end


### PR DESCRIPTION
Release prep for vmpooler-provider-vsphere 3.4.0.\n\n- Bumps version `3.3.4` → `3.4.0`\n- Updates CHANGELOG.md\n- Updates Gemfile.lock\n\n### Included changes\n- (P4DEVOPS-9438) Wire circuit breaker into vSphere provider with connection timeouts (#62)